### PR TITLE
Fix for a 32 vs 64 bit bug preventing image transforms from working properly.

### DIFF
--- a/aquaterm/AQTFunctions.h
+++ b/aquaterm/AQTFunctions.h
@@ -11,10 +11,6 @@
 
 #define COMP_EPS 0.001
 
-// A macro to cast structs that have the same fields 
-// Handy, dangerous and untested...
-#define CAST_STRUCT_TO(struct_t) *(struct_t *)&
-
 // FIXME: test these...
 #define GEQ(a,b) ((a) > (b)-COMP_EPS)
 #define LEQ(a,b) ((a) < (b)+COMP_EPS)

--- a/aquaterm/AQTGraphicDrawingMethods.m
+++ b/aquaterm/AQTGraphicDrawingMethods.m
@@ -266,6 +266,19 @@ static float _aqtMinimumLinewidth;
 
 @implementation AQTImage (AQTImageDrawing)
 
+NSAffineTransformStruct AQTConvertTransformStructToNS(AQTAffineTransformStruct t)
+{
+    NSAffineTransformStruct tmp = {
+        .m11 = (CGFloat)t.m11,
+        .m12 = (CGFloat)t.m12,
+        .m21 = (CGFloat)t.m21,
+        .m22 = (CGFloat)t.m22,
+        .tX = (CGFloat)t.tX,
+        .tY = (CGFloat)t.tY
+    };
+    return tmp;
+}
+
 -(NSRect)updateBounds
 {
    NSAffineTransform *transf = [NSAffineTransform transform];
@@ -274,7 +287,7 @@ static float _aqtMinimumLinewidth;
    {
       tmpBounds = [self bounds];
    } else {
-      [transf setTransformStruct:CAST_STRUCT_TO(NSAffineTransformStruct)transform];
+      [transf setTransformStruct:AQTConvertTransformStructToNS(transform)];
       // FIXME: This is lazy beyond any reasonable measure...
       tmpBounds = [[transf transformBezierPath:[NSBezierPath bezierPathWithRect:NSMakeRect(0, 0, bitmapSize.width, bitmapSize.height)]] bounds];
       [self  setBounds:tmpBounds];
@@ -325,7 +338,7 @@ static float _aqtMinimumLinewidth;
             context = [NSGraphicsContext currentContext];
             [context saveGraphicsState];
          }
-         [transf setTransformStruct:CAST_STRUCT_TO(NSAffineTransformStruct)transform];
+         [transf setTransformStruct:AQTConvertTransformStructToNS(transform)];
          [transf concat];
          [_cache drawAtPoint:NSMakePoint(0,0)
                     fromRect:NSMakeRect(0,0,[_cache size].width,[_cache size].height)


### PR DESCRIPTION
Hi Mojca, 

this is a fix for a bug I found when looking into a comment made by Ethan over at the gnuplot site.

BTW, I looked over the sources with an eye to clean up the code and modernize it some time ago. In the process I started https://github.com/persquare/aquaterm2 which might some day become a replacement for the aging original AquaTerm. Most stuff is working and with much less (and likely easier to understand) code. It is however 10.7+ only. Try it out if you like, the API should be the same.    
