### PR TITLE
Fix Xcode 10 build

### DIFF
--- a/aquaterm/AquaTerm.xcodeproj/project.pbxproj
+++ b/aquaterm/AquaTerm.xcodeproj/project.pbxproj
@@ -28,7 +28,6 @@
 		CB3949DA0E8D7A5B00BA7404 /* AquaTerm.bridgesupport in Resources */ = {isa = PBXBuildFile; fileRef = CB3949D90E8D7A5B00BA7404 /* AquaTerm.bridgesupport */; };
 		CB58A20006F9A60900AF8A5E /* AQTAdapter.html in Resources */ = {isa = PBXBuildFile; fileRef = CB58A1FE06F9A60900AF8A5E /* AQTAdapter.html */; };
 		CB58A20106F9A60900AF8A5E /* help.html in Resources */ = {isa = PBXBuildFile; fileRef = CB58A1FF06F9A60900AF8A5E /* help.html */; };
-		CB58A20206F9A62300AF8A5E /* help.html in CopyFiles */ = {isa = PBXBuildFile; fileRef = CB58A1FF06F9A60900AF8A5E /* help.html */; };
 		CB58A23B06FA0FB600AF8A5E /* ReadMe.rtf in Resources */ = {isa = PBXBuildFile; fileRef = CB58A23A06FA0FB600AF8A5E /* ReadMe.rtf */; };
 		CB72184906072CF6008DCEAD /* ReleaseNotes in Resources */ = {isa = PBXBuildFile; fileRef = CB72184806072CF6008DCEAD /* ReleaseNotes */; };
 		CB91252B07CB488C001D5EAF /* AQTAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF3082D04D51B9300EBD329 /* AQTAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -111,19 +110,6 @@
 			remoteInfo = AQTFwk;
 		};
 /* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		CB58A1F406F9A53300AF8A5E /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 7;
-			files = (
-				CB58A20206F9A62300AF8A5E /* help.html in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
@@ -546,7 +532,6 @@
 				CBC4B43205E4C784001BE8D7 /* Resources */,
 				CBC4B43B05E4C784001BE8D7 /* Sources */,
 				CBC4B44505E4C784001BE8D7 /* Frameworks */,
-				CB58A1F406F9A53300AF8A5E /* CopyFiles */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
This fixes the Xcode 10 build by removing a duplicate copy for the help file.